### PR TITLE
Add return typehints to toString methods for compatibility with PHPUnit 7.0

### DIFF
--- a/PhpUnit/ConfigurationValuesAreInvalidConstraint.php
+++ b/PhpUnit/ConfigurationValuesAreInvalidConstraint.php
@@ -41,7 +41,7 @@ class ConfigurationValuesAreInvalidConstraint extends AbstractConfigurationConst
         $this->fail($other, $description);
     }
 
-    public function toString()
+    public function toString(): string
     {
         $toString = 'is invalid for the given configuration';
 

--- a/PhpUnit/ConfigurationValuesAreValidConstraint.php
+++ b/PhpUnit/ConfigurationValuesAreValidConstraint.php
@@ -34,7 +34,7 @@ class ConfigurationValuesAreValidConstraint extends AbstractConfigurationConstra
         }
     }
 
-    public function toString()
+    public function toString(): string
     {
         return 'is valid for the given configuration';
     }

--- a/PhpUnit/ProcessedConfigurationEqualsConstraint.php
+++ b/PhpUnit/ProcessedConfigurationEqualsConstraint.php
@@ -29,8 +29,9 @@ class ProcessedConfigurationEqualsConstraint extends AbstractConfigurationConstr
         return $constraint->evaluate($processedConfiguration, '', $returnResult);
     }
 
-    public function toString()
+    public function toString(): string
     {
         // won't be used, this constraint only wraps IsEqual
+        return '';
     }
 }

--- a/Tests/PhpUnit/ProcessedConfigurationEqualsConstraintTest.php
+++ b/Tests/PhpUnit/ProcessedConfigurationEqualsConstraintTest.php
@@ -47,6 +47,6 @@ class ProcessedConfigurationEqualsConstraintTest extends TestCase
             array()
         );
 
-        $this->assertNull($constraint->toString());
+        $this->assertEquals('', $constraint->toString());
     }
 }


### PR DESCRIPTION
Contravariance makes it possible for this to be compatible with both PHPUnit 6 with no return type hints.