### PR TITLE
allow completely empty configuration

### DIFF
--- a/PhpUnit/AbstractConfigurationConstraint.php
+++ b/PhpUnit/AbstractConfigurationConstraint.php
@@ -33,7 +33,7 @@ abstract class AbstractConfigurationConstraint extends Constraint
         }
 
         foreach ($configurationValues as $values) {
-            if (!is_array($values)) {
+            if (!is_array($values) && null !== $values) {
                 throw new \InvalidArgumentException('Configuration values should be an array of arrays');
             }
         }


### PR DESCRIPTION
i have a configuration test where i test that a completely empty configuration is accepted. this test started failing when i updated vendors: https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/blob/187362f0377bf272473fd3bbf113195939ebab82/tests/Unit/DependencyInjection/ConfigurationTest.php#L33

i investigated what the configuration is, and instead of an array there is `false` in the array. with this change, the test works for me.

i don't know exactly where this is coming from or if its a behaviour change for empty configuration in symfony.