### PR TITLE
Fix BC break in PHPUnit 8

### DIFF
--- a/PhpUnit/AbstractConfigurationConstraint.php
+++ b/PhpUnit/AbstractConfigurationConstraint.php
@@ -13,7 +13,9 @@ abstract class AbstractConfigurationConstraint extends Constraint
 
     public function __construct(ConfigurationInterface $configuration, $breadcrumbPath = null)
     {
-        parent::__construct();
+        if (property_exists($this, 'exporter')) {
+            parent::__construct();
+        }
 
         $this->configuration = $configuration;
         $this->breadcrumbPath = $breadcrumbPath;


### PR DESCRIPTION
`Constraint::$exporter` property was made private and `Constraint::__construct` removed in PHPUnit 8: https://github.com/sebastianbergmann/phpunit/issues/3060