### PR TITLE
Updates to allow Symfony 5

### DIFF
--- a/Tests/Partial/Fixtures/ConfigurationStub.php
+++ b/Tests/Partial/Fixtures/ConfigurationStub.php
@@ -9,8 +9,12 @@ class ConfigurationStub implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $root = $treeBuilder->root('root');
+        $treeBuilder = new TreeBuilder('root');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $root = $treeBuilder->getRootNode();
+        } else {
+            $root = $treeBuilder->root('root');
+        }
         $root
             ->children()
                 ->arrayNode('only_test_this_node')

--- a/Tests/Partial/PartialNodeTest.php
+++ b/Tests/Partial/PartialNodeTest.php
@@ -7,7 +7,6 @@ use Matthias\SymfonyConfigTest\Partial\Exception\UndefinedChildNode;
 use Matthias\SymfonyConfigTest\Partial\PartialNode;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\ArrayNode;
-use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\PrototypedArrayNode;
 
@@ -18,8 +17,12 @@ class PartialNodeTest extends TestCase
      */
     public function it_strips_children_that_are_not_in_the_given_path_with_one_name()
     {
-        $treeBuilder = new TreeBuilder();
-        $root = $treeBuilder->root('root');
+        $treeBuilder = new TreeBuilder('root');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $root = $treeBuilder->getRootNode();
+        } else {
+            $root = $treeBuilder->root('root');
+        }
         $root
             ->children()
                 ->arrayNode('node_1')
@@ -45,8 +48,12 @@ class PartialNodeTest extends TestCase
      */
     public function it_strips_children_that_are_not_in_the_given_path_with_several_names()
     {
-        $treeBuilder = new TreeBuilder();
-        $root = $treeBuilder->root('root');
+        $treeBuilder = new TreeBuilder('root');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $root = $treeBuilder->getRootNode();
+        } else {
+            $root = $treeBuilder->root('root');
+        }
         $root
             ->children()
                 ->arrayNode('node_1')
@@ -83,8 +90,12 @@ class PartialNodeTest extends TestCase
      */
     public function it_strips_children_when_leaf_node_is_not_an_array()
     {
-        $treeBuilder = new TreeBuilder();
-        $root = $treeBuilder->root('root');
+        $treeBuilder = new TreeBuilder('root');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $root = $treeBuilder->getRootNode();
+        } else {
+            $root = $treeBuilder->root('root');
+        }
         $root
             ->children()
                 ->arrayNode('node_1')
@@ -110,9 +121,12 @@ class PartialNodeTest extends TestCase
      */
     public function it_does_not_crash_on_prototypes()
     {
-        $treeBuilder = new TreeBuilder();
-        /** @var ArrayNodeDefinition $root */
-        $root = $treeBuilder->root('root');
+        $treeBuilder = new TreeBuilder('root');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $root = $treeBuilder->getRootNode();
+        } else {
+            $root = $treeBuilder->root('root');
+        }
         $root
             ->prototype('array')
                 ->children()
@@ -141,8 +155,12 @@ class PartialNodeTest extends TestCase
      */
     public function it_fails_when_a_requested_child_node_does_not_exist()
     {
-        $treeBuilder = new TreeBuilder();
-        $root = $treeBuilder->root('root');
+        $treeBuilder = new TreeBuilder('root');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $root = $treeBuilder->getRootNode();
+        } else {
+            $root = $treeBuilder->root('root');
+        }
         $root
             ->children()
                 ->arrayNode('sub_node')
@@ -162,8 +180,12 @@ class PartialNodeTest extends TestCase
      */
     public function it_fails_when_a_requested_child_node_is_no_array_node_itself_and_path_not_empty()
     {
-        $treeBuilder = new TreeBuilder();
-        $root = $treeBuilder->root('root');
+        $treeBuilder = new TreeBuilder('root');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $root = $treeBuilder->getRootNode();
+        } else {
+            $root = $treeBuilder->root('root');
+        }
         $root
             ->children()
                 ->arrayNode('sub_node')

--- a/Tests/Partial/PartialProcessorTest.php
+++ b/Tests/Partial/PartialProcessorTest.php
@@ -14,8 +14,12 @@ class PartialProcessorTest extends TestCase
      */
     public function it_processes_only_the_values_in_the_breadcrumb_path_for_a_given_node()
     {
-        $treeBuilder = new TreeBuilder();
-        $root = $treeBuilder->root('root');
+        $treeBuilder = new TreeBuilder('root');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $root = $treeBuilder->getRootNode();
+        } else {
+            $root = $treeBuilder->root('root');
+        }
         $root
             ->children()
                 ->arrayNode('only_test_this_node')

--- a/Tests/PhpUnit/Fixtures/AlwaysValidConfiguration.php
+++ b/Tests/PhpUnit/Fixtures/AlwaysValidConfiguration.php
@@ -9,9 +9,10 @@ class AlwaysValidConfiguration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-
-        $treeBuilder->root('root');
+        $treeBuilder = new TreeBuilder('root');
+        if (!method_exists($treeBuilder, 'getRootNode')) {
+            $treeBuilder->root('root');
+        }
 
         return $treeBuilder;
     }

--- a/Tests/PhpUnit/Fixtures/ConfigurationWithMultipleArrayKeys.php
+++ b/Tests/PhpUnit/Fixtures/ConfigurationWithMultipleArrayKeys.php
@@ -9,9 +9,13 @@ class ConfigurationWithMultipleArrayKeys implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('root');
-        $rootNode
+        $treeBuilder = new TreeBuilder('root');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $root = $treeBuilder->getRootNode();
+        } else {
+            $root = $treeBuilder->root('root');
+        }
+        $root
             ->children()
                 ->arrayNode('array_node_1')
                     ->isRequired()

--- a/Tests/PhpUnit/Fixtures/ConfigurationWithRequiredValue.php
+++ b/Tests/PhpUnit/Fixtures/ConfigurationWithRequiredValue.php
@@ -9,10 +9,13 @@ class ConfigurationWithRequiredValue implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-
-        $rootNode = $treeBuilder->root('root');
-        $rootNode
+        $treeBuilder = new TreeBuilder('root');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $root = $treeBuilder->getRootNode();
+        } else {
+            $root = $treeBuilder->root('root');
+        }
+        $root
             ->isRequired()
             ->children()
                 ->scalarNode('required_value')

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "symfony/config": "^2.7 || ^3.4 || ^4.0"
+        "symfony/config": "^2.7 || ^3.4 || ^4.0 || ^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0 || ^8.0"


### PR DESCRIPTION
- Update `symfony/config` to allow ^5.0"
- Update deprecated use of `TreeBuilder`

The constraint is a no-brainer, I just wasn't sure of the best approach on the use of `TreeBuilder` in tests for Symfony <4.2, so please feel free to ask for changes.