### PR TITLE
Support phpunit 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,24 +10,26 @@ matrix:
     fast_finish: true
     include:
           # Minimum supported Symfony version with the latest PHP version
-        - php: 7.2
+        - php: 7.4
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
 
           # Test the latest stable release
         - php: 7.1
         - php: 7.2
+        - php: 7.3
+        - php: 7.4
           env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text"
 
           # Force some major versions of Symfony
-        - php: 7.2
+        - php: 7.4
           env: DEPENDENCIES="dunglas/symfony-lock:^2"
-        - php: 7.2
+        - php: 7.4
           env: DEPENDENCIES="dunglas/symfony-lock:^3"
-        - php: 7.2
+        - php: 7.4
           env: DEPENDENCIES="dunglas/symfony-lock:^4"
 
           # Latest commit to master
-        - php: 7.2
+        - php: 7.4
           env: STABILITY="dev"
 
     allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.1.1
+
+- Support for PHPUnit9.
+
 ## 4.1.0
 
 - Support for Symfony5. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.1.1
+## 4.2.0
 
 - Support for PHPUnit9.
 

--- a/PhpUnit/ConfigurationValuesAreInvalidConstraint.php
+++ b/PhpUnit/ConfigurationValuesAreInvalidConstraint.php
@@ -24,7 +24,7 @@ class ConfigurationValuesAreInvalidConstraint extends AbstractConfigurationConst
         $this->useRegExp = $useRegExp;
     }
 
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, $description = '', $returnResult = false): ?bool
     {
         $this->validateConfigurationValuesArray($other);
 
@@ -39,6 +39,8 @@ class ConfigurationValuesAreInvalidConstraint extends AbstractConfigurationConst
         }
 
         $this->fail($other, $description);
+
+        return null;
     }
 
     public function toString(): string

--- a/PhpUnit/ConfigurationValuesAreValidConstraint.php
+++ b/PhpUnit/ConfigurationValuesAreValidConstraint.php
@@ -12,7 +12,7 @@ class ConfigurationValuesAreValidConstraint extends AbstractConfigurationConstra
         parent::__construct($configuration, $breadcrumbPath);
     }
 
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, $description = '', $returnResult = false): ?bool
     {
         $this->validateConfigurationValuesArray($other);
 
@@ -32,6 +32,8 @@ class ConfigurationValuesAreValidConstraint extends AbstractConfigurationConstra
         if (!$success) {
             $this->fail($other, $description);
         }
+
+        return null;
     }
 
     public function toString(): string

--- a/PhpUnit/ProcessedConfigurationEqualsConstraint.php
+++ b/PhpUnit/ProcessedConfigurationEqualsConstraint.php
@@ -20,7 +20,7 @@ class ProcessedConfigurationEqualsConstraint extends AbstractConfigurationConstr
         parent::__construct($configuration, $breadcrumbPath);
     }
 
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, $description = '', $returnResult = false): ?bool
     {
         $processedConfiguration = $this->processConfiguration($this->configurationValues);
 

--- a/README.md
+++ b/README.md
@@ -268,9 +268,9 @@ public function processed_configuration_for_array_node_1(): void
 
 ## Version Guidance
 
-| Version | Released     | PHPUnit     | Status     |
-|---------|--------------| ------------|------------|
-| 4.x     | Mar 5, 2018  | 7.x and 8.x | Latest     |
-| 3.x     | Nov 30, 2017 | 6.x         | Bugfixes   |
-| 2.x     | Jun 18, 2016 | 4.x and 5.x | EOL        |
-| 1.x     | Oct 12, 2014 | 3.x         | EOL
+| Version | Released     | PHPUnit             | Status     |
+|---------|--------------| --------------------|------------|
+| 4.x     | Mar 5, 2018  | 7.x and 8.x and 9.x | Latest     |
+| 3.x     | Nov 30, 2017 | 6.x                 | Bugfixes   |
+| 2.x     | Jun 18, 2016 | 4.x and 5.x         | EOL        |
+| 1.x     | Oct 12, 2014 | 3.x                 | EOL        |

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/config": "^2.7 || ^3.4 || ^4.0 || ^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0 || ^8.0"
+        "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
     },
     "conflict": {
         "phpunit/phpunit": "<7.0"


### PR DESCRIPTION
- Updated Constraint classes with "?bool" return type to be compatible with PHPUnit 9 and added missing `return null`
- Updated travisCI config to run tests with PHP 7.3 and PHP 7.4
- added PHPUnit 9 to composer.json
- updated Changelog and README