### PR TITLE
Add support for PHPUnit 10; drop legacy PHP, PHPUnit, and Symfony support; CI updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,24 +16,35 @@ jobs:
                     - '7.3'
                     - '7.4'
                     - '8.0'
+                    - '8.1'
+                    - '8.2'
                 dependency:
                     - ''
                 symfony:
                     - '4.4.*'
-                    - '5.3.*'
+                    - '5.4.*'
+                    - '6.2.*'
                 include:
                     - php: '7.1'
                       symfony: '4.4.*'
                       dependency: 'lowest'
-                    - php: '8.0'
-                      symfony: '6.0.*'
                 exclude:
                     - php: '7.1'
-                      symfony: '5.3.*'
+                      symfony: '5.4.*'
+                    - php: '7.1'
+                      symfony: '6.2.*'
+                    - php: '7.2'
+                      symfony: '6.2.*'
+                    - php: '7.3'
+                      symfony: '6.2.*'
+                    - php: '7.4'
+                      symfony: '6.2.*'
+                    - php: '8.0'
+                      symfony: '6.2.*'
             fail-fast: false
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -42,18 +53,12 @@ jobs:
                   extensions: pcov
                   tools: flex
 
-            - name: Prefer unstable Composer dependencies for Symfony 6.0
-              if: matrix.symfony == '6.0.*'
-              run: |
-                composer config prefer-stable false
-                composer config minimum-stability dev
-
             - name: Get Composer Cache Directory
               id: composer-cache
               run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
             - name: Cache dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
                   key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,36 +11,17 @@ jobs:
         strategy:
             matrix:
                 php:
-                    - '7.1'
-                    - '7.2'
-                    - '7.3'
-                    - '7.4'
-                    - '8.0'
                     - '8.1'
                     - '8.2'
                 dependency:
                     - ''
                 symfony:
-                    - '4.4.*'
                     - '5.4.*'
                     - '6.2.*'
                 include:
-                    - php: '7.1'
-                      symfony: '4.4.*'
-                      dependency: 'lowest'
-                exclude:
-                    - php: '7.1'
+                    - php: '8.1'
                       symfony: '5.4.*'
-                    - php: '7.1'
-                      symfony: '6.2.*'
-                    - php: '7.2'
-                      symfony: '6.2.*'
-                    - php: '7.3'
-                      symfony: '6.2.*'
-                    - php: '7.4'
-                      symfony: '6.2.*'
-                    - php: '8.0'
-                      symfony: '6.2.*'
+                      dependency: 'lowest'
             fail-fast: false
         steps:
             - name: Checkout

--- a/Partial/PartialNode.php
+++ b/Partial/PartialNode.php
@@ -99,15 +99,10 @@ class PartialNode
      */
     private static function nodeChildrenProperty()
     {
-        if (!isset(self::$nodeChildrenProperty)) {
-            self::$nodeChildrenProperty = new \ReflectionProperty(
-                ArrayNode::class,
-                'children'
-            );
-            self::$nodeChildrenProperty->setAccessible(true);
-        }
-
-        return self::$nodeChildrenProperty;
+        return self::$nodeChildrenProperty ??= new \ReflectionProperty(
+            ArrayNode::class,
+            'children'
+        );
     }
 
     /**
@@ -115,14 +110,9 @@ class PartialNode
      */
     private static function nodePrototypeProperty()
     {
-        if (!isset(self::$nodePrototypeProperty)) {
-            self::$nodePrototypeProperty = new \ReflectionProperty(
-                PrototypedArrayNode::class,
-                'prototype'
-            );
-            self::$nodePrototypeProperty->setAccessible(true);
-        }
-
-        return self::$nodePrototypeProperty;
+        return self::$nodePrototypeProperty ??= new \ReflectionProperty(
+            PrototypedArrayNode::class,
+            'prototype'
+        );
     }
 }

--- a/PhpUnit/AbstractConfigurationConstraint.php
+++ b/PhpUnit/AbstractConfigurationConstraint.php
@@ -13,10 +13,6 @@ abstract class AbstractConfigurationConstraint extends Constraint
 
     public function __construct(ConfigurationInterface $configuration, $breadcrumbPath = null)
     {
-        if (is_callable([Constraint::class, '__construct'])) {
-            parent::__construct();
-        }
-
         $this->configuration = $configuration;
         $this->breadcrumbPath = $breadcrumbPath;
     }

--- a/PhpUnit/ConfigurationValuesAreInvalidConstraint.php
+++ b/PhpUnit/ConfigurationValuesAreInvalidConstraint.php
@@ -3,7 +3,11 @@
 namespace Matthias\SymfonyConfigTest\PhpUnit;
 
 use PHPUnit\Framework\Constraint\ExceptionMessage;
+use PHPUnit\Framework\Constraint\ExceptionMessageIsOrContains;
+use PHPUnit\Framework\Constraint\ExceptionMessageMatchesRegularExpression;
 use PHPUnit\Framework\Constraint\ExceptionMessageRegularExpression;
+use PHPUnit\Framework\Constraint\MessageIsOrContains;
+use PHPUnit\Framework\Constraint\MessageMatchesRegularExpression;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
@@ -67,9 +71,31 @@ class ConfigurationValuesAreInvalidConstraint extends AbstractConfigurationConst
     private function createPhpUnitConstraint()
     {
         if ($this->useRegExp) {
+            // Available since PHPUnit 10.0.15
+            if (class_exists(ExceptionMessageMatchesRegularExpression::class)) {
+                return new ExceptionMessageMatchesRegularExpression($this->expectedMessage);
+            }
+
+            // Available between PHPUnit 10.0.0 and 10.0.14 (inclusive)
+            if (class_exists(MessageMatchesRegularExpression::class)) {
+                return new MessageMatchesRegularExpression('exception', $this->expectedMessage);
+            }
+
+            // Available in PHPUnit 9.6
             return new ExceptionMessageRegularExpression($this->expectedMessage);
         }
 
+        // Available since PHPUnit 10.0.15
+        if (class_exists(ExceptionMessageIsOrContains::class)) {
+            return new ExceptionMessageIsOrContains($this->expectedMessage);
+        }
+
+        // Available between PHPUnit 10.0.0 and 10.0.14 (inclusive)
+        if (class_exists(MessageIsOrContains::class)) {
+            return new MessageIsOrContains('exception', $this->expectedMessage);
+        }
+
+        // Available in PHPUnit 9.6
         return new ExceptionMessage($this->expectedMessage);
     }
 }

--- a/Tests/Partial/Fixtures/ConfigurationStub.php
+++ b/Tests/Partial/Fixtures/ConfigurationStub.php
@@ -10,11 +10,7 @@ class ConfigurationStub implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('root');
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $root = $treeBuilder->getRootNode();
-        } else {
-            $root = $treeBuilder->root('root');
-        }
+        $root = $treeBuilder->getRootNode();
         $root
             ->children()
                 ->arrayNode('only_test_this_node')

--- a/Tests/Partial/PartialNodeTest.php
+++ b/Tests/Partial/PartialNodeTest.php
@@ -18,11 +18,7 @@ class PartialNodeTest extends TestCase
     public function it_strips_children_that_are_not_in_the_given_path_with_one_name()
     {
         $treeBuilder = new TreeBuilder('root');
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $root = $treeBuilder->getRootNode();
-        } else {
-            $root = $treeBuilder->root('root');
-        }
+        $root = $treeBuilder->getRootNode();
         $root
             ->children()
                 ->arrayNode('node_1')
@@ -49,11 +45,7 @@ class PartialNodeTest extends TestCase
     public function it_strips_children_that_are_not_in_the_given_path_with_several_names()
     {
         $treeBuilder = new TreeBuilder('root');
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $root = $treeBuilder->getRootNode();
-        } else {
-            $root = $treeBuilder->root('root');
-        }
+        $root = $treeBuilder->getRootNode();
         $root
             ->children()
                 ->arrayNode('node_1')
@@ -91,11 +83,7 @@ class PartialNodeTest extends TestCase
     public function it_strips_children_when_leaf_node_is_not_an_array()
     {
         $treeBuilder = new TreeBuilder('root');
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $root = $treeBuilder->getRootNode();
-        } else {
-            $root = $treeBuilder->root('root');
-        }
+        $root = $treeBuilder->getRootNode();
         $root
             ->children()
                 ->arrayNode('node_1')
@@ -122,11 +110,7 @@ class PartialNodeTest extends TestCase
     public function it_does_not_crash_on_prototypes()
     {
         $treeBuilder = new TreeBuilder('root');
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $root = $treeBuilder->getRootNode();
-        } else {
-            $root = $treeBuilder->root('root');
-        }
+        $root = $treeBuilder->getRootNode();
         $root
             ->prototype('array')
                 ->children()
@@ -156,11 +140,7 @@ class PartialNodeTest extends TestCase
     public function it_fails_when_a_requested_child_node_does_not_exist()
     {
         $treeBuilder = new TreeBuilder('root');
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $root = $treeBuilder->getRootNode();
-        } else {
-            $root = $treeBuilder->root('root');
-        }
+        $root = $treeBuilder->getRootNode();
         $root
             ->children()
                 ->arrayNode('sub_node')
@@ -181,11 +161,7 @@ class PartialNodeTest extends TestCase
     public function it_fails_when_a_requested_child_node_is_no_array_node_itself_and_path_not_empty()
     {
         $treeBuilder = new TreeBuilder('root');
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $root = $treeBuilder->getRootNode();
-        } else {
-            $root = $treeBuilder->root('root');
-        }
+        $root = $treeBuilder->getRootNode();
         $root
             ->children()
                 ->arrayNode('sub_node')
@@ -203,7 +179,6 @@ class PartialNodeTest extends TestCase
     private function nodeOnlyHasChild(ArrayNode $node, $nodeName)
     {
         $property = new \ReflectionProperty($node, 'children');
-        $property->setAccessible(true);
         $children = $property->getValue($node);
 
         $this->assertCount(1, $children);

--- a/Tests/Partial/PartialProcessorTest.php
+++ b/Tests/Partial/PartialProcessorTest.php
@@ -15,11 +15,7 @@ class PartialProcessorTest extends TestCase
     public function it_processes_only_the_values_in_the_breadcrumb_path_for_a_given_node()
     {
         $treeBuilder = new TreeBuilder('root');
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $root = $treeBuilder->getRootNode();
-        } else {
-            $root = $treeBuilder->root('root');
-        }
+        $root = $treeBuilder->getRootNode();
         $root
             ->children()
                 ->arrayNode('only_test_this_node')
@@ -55,7 +51,8 @@ class PartialProcessorTest extends TestCase
                 'only_test_this_node' => [
                     'scalar_node' => 'yes',
                 ],
-            ], $processedConfig
+            ],
+            $processedConfig
         );
     }
 
@@ -83,7 +80,8 @@ class PartialProcessorTest extends TestCase
                 'only_test_this_node' => [
                     'scalar_node' => 'yes',
                 ],
-            ], $processedConfig
+            ],
+            $processedConfig
         );
     }
 }

--- a/Tests/PhpUnit/ConfigurationTestCaseTraitTest.php
+++ b/Tests/PhpUnit/ConfigurationTestCaseTraitTest.php
@@ -63,11 +63,7 @@ class ConfigurationTestCaseTraitTest extends TestCase
     {
         $this->expectException(ExpectationFailedException::class);
 
-        if (method_exists($this, 'expectExceptionMessageMatches')) {
-            $this->expectExceptionMessageMatches('/^The child (config|node) "required_value" (at path|under) "root" must be configured/');
-        } else {
-            $this->expectExceptionMessageRegExp('/^The child (config|node) "required_value" (at path|under) "root" must be configured/');
-        }
+        $this->expectExceptionMessageMatches('/^The child (config|node) "required_value" (at path|under) "root" must be configured/');
 
         $this->assertConfigurationIsValid(
             [

--- a/Tests/PhpUnit/Fixtures/AlwaysValidConfiguration.php
+++ b/Tests/PhpUnit/Fixtures/AlwaysValidConfiguration.php
@@ -9,11 +9,6 @@ class AlwaysValidConfiguration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder('root');
-        if (!method_exists($treeBuilder, 'getRootNode')) {
-            $treeBuilder->root('root');
-        }
-
-        return $treeBuilder;
+        return new TreeBuilder('root');
     }
 }

--- a/Tests/PhpUnit/Fixtures/ConfigurationWithMultipleArrayKeys.php
+++ b/Tests/PhpUnit/Fixtures/ConfigurationWithMultipleArrayKeys.php
@@ -10,11 +10,7 @@ class ConfigurationWithMultipleArrayKeys implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('root');
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $root = $treeBuilder->getRootNode();
-        } else {
-            $root = $treeBuilder->root('root');
-        }
+        $root = $treeBuilder->getRootNode();
         $root
             ->children()
                 ->arrayNode('array_node_1')

--- a/Tests/PhpUnit/Fixtures/ConfigurationWithRequiredValue.php
+++ b/Tests/PhpUnit/Fixtures/ConfigurationWithRequiredValue.php
@@ -10,11 +10,7 @@ class ConfigurationWithRequiredValue implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('root');
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $root = $treeBuilder->getRootNode();
-        } else {
-            $root = $treeBuilder->root('root');
-        }
+        $root = $treeBuilder->getRootNode();
         $root
             ->isRequired()
             ->children()

--- a/composer.json
+++ b/composer.json
@@ -13,21 +13,21 @@
         }
     ],
     "require": {
-        "php": "^7.1 || ^8.0",
-        "symfony/config": "^4.4 || ^5.3 || ^6.0"
+        "php": "^8.1",
+        "symfony/config": "^5.4 || ^6.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+        "phpunit/phpunit": "^9.6 || ^10.0"
     },
     "conflict": {
-        "phpunit/phpunit": "<7.0"
+        "phpunit/phpunit": "<9.6 || >=11.0"
     },
     "autoload": {
         "psr-4" : { "Matthias\\SymfonyConfigTest\\" : "" }
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.0.x-dev"
+            "dev-master": "5.0.x-dev"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.0/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
          colors="true"
-         verbose="true">
+>
     <testsuites>
         <testsuite name="MatthiasSymfonyConfigTest">
-            <directory suffix="Test.php">Tests</directory>
+            <directory>Tests</directory>
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">.</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+    <coverage>
+        <include>
+            <directory suffix=".php">./</directory>
+        </include>
+        <exclude>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
Fixes #72

This PR does two things (the second dependent on the first to get a valid test environment)

1) Updates the CI config to run tests on PHP 8.1 and 8.2, as well as Symfony 5.4 and 6.2 (skipping 6.0 and 6.1 as they are now EOL)
2) Bumps the supported dependency ranges; Symfony 5.4 and 6.2-6.4, PHPUnit 9.6 and 10, and PHP 8.1+; some conditional code that's no longer needed is dropped
3) Adds support for PHPUnit 10