### PR TITLE
Add support for Symfony 7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,15 +17,20 @@ jobs:
                     - ''
                 symfony:
                     - '5.4.*'
-                    - '6.2.*'
+                    - '6.3.*'
+                    - '6.4.*@beta'
+                    - '7.0.*@beta'
                 include:
                     - php: '8.1'
                       symfony: '5.4.*'
                       dependency: 'lowest'
+                exclude:
+                    - php: '8.1'
+                      symfony: '7.0.*@beta'
             fail-fast: false
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -36,7 +41,7 @@ jobs:
 
             - name: Get Composer Cache Directory
               id: composer-cache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Cache dependencies
               uses: actions/cache@v3

--- a/Tests/Partial/Fixtures/ConfigurationStub.php
+++ b/Tests/Partial/Fixtures/ConfigurationStub.php
@@ -7,7 +7,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class ConfigurationStub implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('root');
         $root = $treeBuilder->getRootNode();

--- a/Tests/PhpUnit/Fixtures/AlwaysValidConfiguration.php
+++ b/Tests/PhpUnit/Fixtures/AlwaysValidConfiguration.php
@@ -7,7 +7,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class AlwaysValidConfiguration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         return new TreeBuilder('root');
     }

--- a/Tests/PhpUnit/Fixtures/ConfigurationWithMultipleArrayKeys.php
+++ b/Tests/PhpUnit/Fixtures/ConfigurationWithMultipleArrayKeys.php
@@ -7,7 +7,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class ConfigurationWithMultipleArrayKeys implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('root');
         $root = $treeBuilder->getRootNode();

--- a/Tests/PhpUnit/Fixtures/ConfigurationWithRequiredValue.php
+++ b/Tests/PhpUnit/Fixtures/ConfigurationWithRequiredValue.php
@@ -7,7 +7,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class ConfigurationWithRequiredValue implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('root');
         $root = $treeBuilder->getRootNode();

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "symfony/config": "^5.4 || ^6.2"
+        "symfony/config": "^5.4 || ^6.3 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6 || ^10.0"
@@ -31,7 +31,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.0.x-dev"
+            "dev-master": "5.1.x-dev"
         }
     }
 }


### PR DESCRIPTION
Adds Symfony 7 support and drops support for the EOL Symfony 6.2 branch, which will help greatly with unblocking folks starting to test against the new major release.