### PR TITLE
Allow phpunit 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         "symfony/config": "^5.4 || ^6.2 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6 || ^10.0"
+        "phpunit/phpunit": "^9.6 || ^10.0 || ^11.0"
     },
     "conflict": {
-        "phpunit/phpunit": "<9.6 || >=11.0"
+        "phpunit/phpunit": "<9.6 || >=12.0"
     },
     "autoload": {
         "psr-4" : { "Matthias\\SymfonyConfigTest\\" : "" },


### PR DESCRIPTION
This allows the installation of phpunit 11 for running the tests in this library.
I've run the tests locally on PHP 8.1, 8.2 and 8.3.
It is giving some deprecation warnings when phpunit 11 is installed, but no errors are reported.

Also adjusts the conflict configuration to allow installation of this package along with phpunit 11.
I've installed this library, with this adjusted config, along with phpunit 11 in a project of my own and did not run into issues doing so. Although I'm not using everything from this library, it appears to be fine to use with phpunit 11.

I know there is already another pullrequest for phpunit 11, but that pull request changes how versions are handled. I think this works just fine.

Let me know if I need to adjust something else. Or of I need to leave the require-dev as is.