### PR TITLE
Remove compat code for unsupported PHPUnit versions

### DIFF
--- a/PhpUnit/ConfigurationValuesAreInvalidConstraint.php
+++ b/PhpUnit/ConfigurationValuesAreInvalidConstraint.php
@@ -2,12 +2,8 @@
 
 namespace Matthias\SymfonyConfigTest\PhpUnit;
 
-use PHPUnit\Framework\Constraint\ExceptionMessage;
 use PHPUnit\Framework\Constraint\ExceptionMessageIsOrContains;
 use PHPUnit\Framework\Constraint\ExceptionMessageMatchesRegularExpression;
-use PHPUnit\Framework\Constraint\ExceptionMessageRegularExpression;
-use PHPUnit\Framework\Constraint\MessageIsOrContains;
-use PHPUnit\Framework\Constraint\MessageMatchesRegularExpression;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
@@ -64,38 +60,12 @@ class ConfigurationValuesAreInvalidConstraint extends AbstractConfigurationConst
             return true;
         }
 
-        return $this->createPhpUnitConstraint()
-            ->evaluate($exception, $description, $returnResult);
-    }
-
-    private function createPhpUnitConstraint()
-    {
         if ($this->useRegExp) {
-            // Available since PHPUnit 10.0.15
-            if (class_exists(ExceptionMessageMatchesRegularExpression::class)) {
-                return new ExceptionMessageMatchesRegularExpression($this->expectedMessage);
-            }
-
-            // Available between PHPUnit 10.0.0 and 10.0.14 (inclusive)
-            if (class_exists(MessageMatchesRegularExpression::class)) {
-                return new MessageMatchesRegularExpression('exception', $this->expectedMessage);
-            }
-
-            // Available in PHPUnit 9.6
-            return new ExceptionMessageRegularExpression($this->expectedMessage);
+            return (new ExceptionMessageMatchesRegularExpression($this->expectedMessage))
+                ->evaluate($exception, $description, $returnResult);
         }
 
-        // Available since PHPUnit 10.0.15
-        if (class_exists(ExceptionMessageIsOrContains::class)) {
-            return new ExceptionMessageIsOrContains($this->expectedMessage);
-        }
-
-        // Available between PHPUnit 10.0.0 and 10.0.14 (inclusive)
-        if (class_exists(MessageIsOrContains::class)) {
-            return new MessageIsOrContains('exception', $this->expectedMessage);
-        }
-
-        // Available in PHPUnit 9.6
-        return new ExceptionMessage($this->expectedMessage);
+        return (new ExceptionMessageIsOrContains($this->expectedMessage))
+            ->evaluate($exception, $description, $returnResult);
     }
 }


### PR DESCRIPTION
Since 10.5 is required, compat code for older versions isn't needed.